### PR TITLE
Updating image to f9926b

### DIFF
--- a/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
@@ -13,5 +13,7 @@ patchesJson6902:
 resources:
 - ../../base/
 images:
+- name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
+  newTag: f9926b
 - name: quay.io/froberge/simple-quarkus-service
   newTag: v2


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:f9926b on gitops-demo/simple-quarkus-service-deploy/app/overlays/prod