### PR TITLE
Updating image to 98b154

### DIFF
--- a/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
@@ -14,6 +14,6 @@ resources:
 - ../../base/
 images:
 - name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
-  newTag: 46f171
+  newTag: 98b154
 - name: quay.io/froberge/simple-quarkus-service
   newTag: v2


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:98b154 on gitops-demo/simple-quarkus-service-deploy/app/overlays/prod