### PR TITLE
Updating image to d3f553

### DIFF
--- a/gitops/service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops/service-deploy/app/overlays/prod/kustomization.yaml
@@ -13,5 +13,7 @@ patchesJson6902:
     name: simple-quarkus-service
     version: v1
 images:
+- name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
+  newTag: d3f553
 - name: quay.io/froberge/simple-quarkus-service
   newTag: v3


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:d3f553 on gitops/service-deploy/app/overlays/prod