### PR TITLE
Updating image to 6edc2c

### DIFF
--- a/gitops/service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops/service-deploy/app/overlays/prod/kustomization.yaml
@@ -14,4 +14,4 @@ patchesJson6902:
     version: v1
 images:
 - name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
-  newTag: d3f553
+  newTag: 6edc2c


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:6edc2c on gitops/service-deploy/app/overlays/prod