### PR TITLE
Updating image to 9e1f37

### DIFF
--- a/gitops/service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops/service-deploy/app/overlays/prod/kustomization.yaml
@@ -14,4 +14,4 @@ patchesJson6902:
     version: v1
 images:
 - name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
-  newTag: 6edc2c
+  newTag: 9e1f37


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:9e1f37 on gitops/service-deploy/app/overlays/prod